### PR TITLE
Issue 8

### DIFF
--- a/.refactorcode.toml.example
+++ b/.refactorcode.toml.example
@@ -4,10 +4,10 @@
 
   # Obtain your API key from https://ai.google.dev/ and set it within the quotation marks:
 
-  API_KEY = "GEMINI API KEY"
+  API_KEY = "YOUR_API_KEY_HERE"
 
 [preferences]
 
   # Specify your prefer generative model (i.e. 1.5f or 1.5p) and set it within the quotation marks:
 
-  MODEL = "Generative AI model to use"
+  MODEL = "YOUR_AI_MODEL_HERE"

--- a/.refactorcode.toml.example
+++ b/.refactorcode.toml.example
@@ -1,0 +1,13 @@
+# .refactorcode.toml.example
+
+[api_keys]
+
+  # Obtain your API key from https://ai.google.dev/ and set it within the quotation marks:
+
+  API_KEY = "GEMINI API KEY"
+
+[preferences]
+
+  # Specify your prefer generative model (i.e. 1.5f or 1.5p) and set it within the quotation marks:
+
+  MODEL = "Generative AI model to use"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # RefactorCode
+
 A console application to reduce bugs, improve performance and improve readability of your code.
 
 https://github.com/user-attachments/assets/9ca694a3-da23-4ae3-b476-1c071e675a66
 
 ## Features
+
 - Checks for any bugs and corrects them (out of bounds, performance issues, logical bugs).
 - Removes commented out and unreachable code.
 - Adds comments to explain existing code.
@@ -11,69 +13,101 @@ https://github.com/user-attachments/assets/9ca694a3-da23-4ae3-b476-1c071e675a66
 
 ## Usage
 
-```
+```bash
 refactorcode ./yourfile
 ```
+
 By the refactored code is displayed in the console. To specify an output file, use `-o`. See [Options](#options)
 
 ## Setup Instructions
 
-Clone the repo:
-```
+### Clone the repo
+
+```bash
 git clone https://github.com/brokoli777/RefactorCode.git
 ```
 
-Install node libraries
-```
+### Install node libraries
+
+```bash
 pnpm install
 ```
+
 OR
-```
+
+```bash
 npm install
 ```
-Get an API Key from here: https://ai.google.dev/aistudio 
+
+Get an API Key from here: https://ai.google.dev/aistudio
 ![Screenshot 2024-09-10 at 3 06 46 PM](https://github.com/user-attachments/assets/958f2257-f16e-4254-ac59-d5342be36b43)
 
-Create a .env file and add the API key like this:
-```
+### Configuration Setup
+
+To configure your application, there are 2 options, creating a `.env` file or a `.toml` file:
+
+**Option 1**: Create a `.env` file in your project root directory, and add the API key like this:
+
+```bash
 API_KEY=YOURAPIKEYHERE
 ```
 
-Link the application
-```
+**Option 2**: Create a `.toml` file named `.refactorcode.toml` in your home directory, and add your API key and/or preferences:
+
+1. **Create the TOML File**:  
+   Open your terminal and run the following command to create a new TOML file in your home directory:
+
+   ```bash
+   touch ~/.refactorcode.toml
+   ```
+
+2. **Copy the Sample Configuration**:  
+   Next, copy the sample configuration from `.refactorcode.toml.example` into your newly created `.refactorcode.toml` file:
+
+   ```bash
+   cp .refactorcode.toml.example ~/.refactorcode.toml
+   ```
+
+3. **Edit the Configuration**:  
+   Open the `.refactorcode.toml` file in your preferred text editor, and add your API key value, and any other preferences (e.g. MODEL) you need.
+
+### Link the application
+
+```bash
+
 npm link
+
 ```
 
-Run the application
-```
+### Run the application
+
+```bash
+
 refactorcode examples/test.py
+
 ```
 
 ## Options
 
 **-m or --model**: Allows to specify the model
 
-Choices: 
+Choices:
+
 - 1.5f (gemini-1.5-flash) (**default**)
 - 1.5p (gemini-1.5-pro)
 
-  ```
-  refactorcode examples/test.py -m 1.5p
-  ```
+```bash
 
-**-o or --output**- Allows to set the output file 
+refactorcode examples/test.py -m 1.5p
+
+```
+
+**-o or --output**- Allows to set the output file
 
 **-t or --token-usage:** Allows get information on the tokens used
 
-```
+```bash
+
 refactorcode examples/test.py -o hello.py
+
 ```
-
-
-
-
-
-
-
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"commander": "^12.1.0",
 				"dotenv": "^16.4.5",
 				"markdown-it": "^14.1.0",
+				"toml": "^3.0.0",
 				"yocto-spinner": "^0.1.0"
 			},
 			"bin": {
@@ -110,6 +111,11 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/toml": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+			"integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
 		},
 		"node_modules/uc.micro": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"commander": "^12.1.0",
 		"dotenv": "^16.4.5",
 		"markdown-it": "^14.1.0",
+		"toml": "^3.0.0",
 		"yocto-spinner": "^0.1.0"
 	},
 	"name": "refactorcode",


### PR DESCRIPTION
Hi! This PR adds the new feature to support using a `.toml` file for API key and preferences (issue #8):
- [x] The program now looks for a custom config file created by the user named `.refactorcode.toml` from the user's home directory: https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L336-L360.
- [x] If `.refactorcode.toml` does not exist, the program can still run based on the logic of handling missing inputs. The program prioritizes `CLI` options first, followed by `.refactorcode.toml` values, then `.env` variables, and lastly, hardcoded values: [API key](https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L34),  [model preference](https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L62).
- [x]  If the `.refactorcode.toml` file exists, but it cannot be parsed properly, the program exits with an error message: https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L352-L356.
- [x] Added `.refactorcode.toml.example` as a template for the users to refer to.
- [x] Added `process.exit(1)` in some `catch` statements to ensure the program stops loading when there is an error. This is because when I was testing running the program without an API key, there was an error message, however the program was still loading (spinner remained active) and I had to press `Ctrl + c` to exit: https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L331, https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/index.js#L293. 
- [x] Updated `README.md` to reflect the new feature: https://github.com/vinhyan/RefactorCode/blob/7df1f7af267d00bb40a33bad32bb1fc8b67efe1c/README.md?plain=1#L45-L72

Let me know if there is anything I've missed or bug I need to fix.

Thanks for the collab opportunity!