### PR TITLE
add more test cases for `file.test.js`

### DIFF
--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1,18 +1,25 @@
-import { readFile, checkIfDirectory } from "../src/fileUtils";
+import { checkIfDirectory, readFile } from "../src/fileUtils";
 
 describe("File Utility", () => {
-
-    test("Read File", () => {
-
-      readFile("./examples/test.txt").then((data) => {
-        expect(data).toBe("Hello World");
-      });
-   
+  test("Read File", () => {
+    readFile("./examples/test.txt").then((data) => {
+      expect(data).toBe("Hello World");
     });
+  });
 
-    test('should return true if the path is a directory', async () => {
-      const result = await checkIfDirectory('./examples');
-      expect(result).toBe(true);
+  test("Read File Error, return null", () => {
+    readFile("./examples/does-not-exist.txt").then((data) => {
+      expect(data).toBe(null);
     });
+  });
 
+  test("should return true if the path is a directory", async () => {
+    const result = await checkIfDirectory("./examples");
+    expect(result).toBe(true);
+  });
+
+  test("should return false if the path is not a directory", async () => {
+    const result = await checkIfDirectory("./examples/dummy-file.txt");
+    expect(result).toBe(false);
+  });
 });


### PR DESCRIPTION
This PR adds 2 test cases in `file.test.js`:
* `readFile` reads a non-existent file, returns `null`.
* `checkIfDirectory` returns `false` for a path that is not a directory.